### PR TITLE
Updated image to Centos-6.7

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,7 +56,7 @@ SCRIPT
 Vagrant.configure("2") do |config|
 
 	# Define base image
-	config.vm.box = "puphpet/centos65-x64"
+	config.vm.box = "bento/centos-6.7"
 
 	# Manage /etc/hosts on host and VMs
   	config.hostmanager.enabled = false


### PR DESCRIPTION
Hello the image "puphpet/centos65-x64" is broken.
Lets use "bento/centos-6.7".
